### PR TITLE
Modified to save aliases in one Flatpak specific alias file

### DIFF
--- a/flatalias
+++ b/flatalias
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+alias_file=~/.flatalias
+
 # Get list of Flatpak apps
-app_list=$(flatpak list --app)
+app_list=$(flatpak list --app --columns=application)
 
 # Loop through each app in the list
 while read -r line; do
@@ -14,17 +16,21 @@ while read -r line; do
     # Convert app name to lowercase
     app_name=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
 
-    # Search for app name and ID in ~/.bashrc and ~/.config/fish/config.fish
-    if ! grep -q "$app_id" ~/.bashrc; then
-        echo "alias $app_name=\"flatpak run $app_id\"" >> ~/.bashrc && echo "$app_name alias created in bashrc"
-    fi
-
-    if ! grep -q "$app_id" ~/.config/fish/config.fish; then
-        echo "alias $app_name='flatpak run $app_id'" >> ~/.config/fish/config.fish && echo "$app_name alias created in config.fish"
-    fi
-
-    if ! grep -q "$app_id" ~/.zshrc; then
-        echo "alias $app_name='flatpak run $app_id'" >> ~/.zshrc && echo "$app_name alias created in zshrc"
+    # Search for app name and ID in alias_file
+    if ! grep -q "$app_id" $alias_file; then
+        echo "alias $app_name=\"flatpak run $app_id\"" >> $alias_file && echo "$app_name alias created in $alias_file"
     fi
 
 done <<< "$app_list"
+
+# Search for app name and ID in shell config files
+rc_files=(~/.bashrc ~/.config/fish/config.fish ~/.zshrc)
+
+for rc_file in "${rc_files[@]}"
+do
+    if [ -f ${rc_file} ]; then
+        if ! grep -q "${alias_file}" $rc_file; then
+            echo "source $alias_file" >> $rc_file
+        fi
+    fi
+done


### PR DESCRIPTION
I saw your project in a [comment on Lemmy](https://feddit.de/comment/2748434), and I liked the thought of making easy commands for my Flatpak applications. However, I already like putting all my aliases in a separate file from ~/.bashrc (I use ~/.bash_aliases) and then sourcing it into ~/.bashrc. So I modified your script to write all the Flatpak alias commands to one file, and then it sources that file into the shell config files if they exist. 

And I also make a change to the initial flatpak command, since it wasn't working for me without specifying the columns. 